### PR TITLE
Update engri_1101.yml

### DIFF
--- a/software_install/engri_1101.yml
+++ b/software_install/engri_1101.yml
@@ -4,6 +4,7 @@ channels:
   - defaults
   - conda-forge
 dependencies:
+  - mamba
   - python=3.7
   - nb_conda
   - ipykernel


### PR DESCRIPTION
while mamba isnt necessary for the work per se, the libc solver it uses requires substantial less memory than the python dependency solver used by conda and is necessary for the codio systems to install/update without fuss.