### PR TITLE
Use custom create_etching_network function for etching TSP

### DIFF
--- a/labs/travelling_salesman_problem/travelling_salesman_problem_lab_key.ipynb
+++ b/labs/travelling_salesman_problem/travelling_salesman_problem_lab_key.ipynb
@@ -1131,7 +1131,7 @@
    "outputs": [],
    "source": [
     "nodes = pd.read_csv('data/xqf131_etching.csv', index_col=0)\n",
-    "G = vl.create_network(nodes, directed=True, manhattan=False, x_i='x_start', y_i='y_start', x_j='x_end', y_j='y_end')\n",
+    "G = create_etching_network(nodes)\n",
     "show(etching_tour_plot(G, [], width=600))"
    ]
   },
@@ -1220,7 +1220,7 @@
    "outputs": [],
    "source": [
     "# Optimal\n",
-    "show(etching_tour_plot(G, optimal_tour('xqf131_etching'), width=600))\n"
+    "show(etching_tour_plot(G, optimal_tour('xqf131_etching'), width=600))"
    ]
   },
   {


### PR DESCRIPTION
An incompatible update in vinal 0.4.0 uses the expected "x" and "y" attributes of a node to define the "name" attribute of the node. This "name" attribute is then used by plotting functions. Since the etching example doesn't supply these attributes, we can no longer get away with using the vinal `create_network` function. Hence,
`create_etching_network` is added to `tsp.py`.